### PR TITLE
New runner name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 12.x
           - 14.x
           - 16.x
           - 18.x

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
           - ./jest/25
           - ./jest/26
           - ./jest/27
+          - ./jest/29
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10.x
           - 12.x
           - 14.x
           - 16.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ## [Unreleased] - TBD
 
--
 
-## [v2.2.2] (2024-07-14)
+## [v3.2.2] (2024-07-14)
 
 - Change runner name
-- Add support for Jest 29
+- Add tests for Jest 29
 
 ## [v2.2.1] (2024-07-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## [Unreleased] - TBD
 
-- 
+-
+
+## [v2.2.2] (2024-07-14)
+
+- Change runner name
+- Add support for Jest 29
+
+## [v2.2.1] (2024-07-14)
+
+- Added information about the currently running groups to environment variables.
+- Updated dependencies to the latest versions.
 
 ## [v2.2.0] (2022-03-28)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Downloads/week](https://img.shields.io/npm/dw/jest-runner-grouped-tests.svg)](https://www.npmjs.com/package/jest-runner-grouped-tests)
 [![License](https://img.shields.io/npm/l/jest-runner-grouped-tests.svg)](https://github.com/saritvakrat/jest-runner-grouped-tests/blob/master/package.json)
 
-A test runner that allows you to tag your tests and execute specific groups of tests with Jest.
+A test runner that allows you to tag your tests and execute specific groups of tests with Jest. This runner is based on the original repository that was [archived](https://github.com/eugene-manuilov/jest-runner-groups)
 
 ## Installation
 
@@ -65,7 +65,7 @@ To make Jest use this runner, you need to update your Jest config and add `group
     "dependencies": {
     },
     "jest": {
-        "runner": "groups"
+        "runner": "jest-runner-grouped-tests"
     }
 }
 ```
@@ -75,7 +75,7 @@ Or in the `jest.config.js` file:
 ```javascript
 module.exports = {
     ...
-    runner: "groups"
+    runner: "jest-runner-grouped-tests"
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -7,8 +7,13 @@ const TestRunner = Object.prototype.hasOwnProperty.call( JestRunner, 'default' )
 
 const ARG_PREFIX = '--group=';
 
-class Group2Runner extends TestRunner {
+class GroupsRunner extends TestRunner {
 
+	/**
+	 * Parses command line arguments to identify groups to include and exclude
+	 * @param args
+	 * @return {{include: *[], exclude: *[]}}
+	 */
 	static getGroups( args ) {
 		const include = [];
 		const exclude = [];
@@ -30,6 +35,13 @@ class Group2Runner extends TestRunner {
 		};
 	}
 
+	/**
+	 * Filters tests based on the specified groups.
+	 * @param include
+	 * @param exclude
+	 * @param test
+	 * @return {boolean}
+	 */
 	static filterTest( { include, exclude }, test ) {
 		let found = include.length === 0;
 
@@ -53,8 +65,18 @@ class Group2Runner extends TestRunner {
 		return found;
 	}
 
+	/**
+	 * Overrides the default runTests method to filter tests based on groups before running them.
+	 * @param tests
+	 * @param watcher
+	 * @param onStart
+	 * @param onResult
+	 * @param onFailure
+	 * @param options
+	 * @return {Promise<void>}
+	 */
 	runTests( tests, watcher, onStart, onResult, onFailure, options ) {
-		const groups = GroupRunner.getGroups( process.argv );
+		const groups = GroupsRunner.getGroups( process.argv );
 
 		groups.include.forEach( ( group ) => {
 			if ( groups.exclude.includes( group ) ) {
@@ -67,7 +89,7 @@ class Group2Runner extends TestRunner {
 
 		return super.runTests(
 			groups.include.length > 0 || groups.exclude.length > 0
-				? tests.filter( ( test ) => GroupRunner.filterTest( groups, test ) )
+				? tests.filter( ( test ) => GroupsRunner.filterTest( groups, test ) )
 				: tests,
 			watcher,
 			onStart,
@@ -79,4 +101,4 @@ class Group2Runner extends TestRunner {
 
 }
 
-module.exports = Group2Runner;
+module.exports = GroupsRunner;

--- a/jest/24/package.json
+++ b/jest/24/package.json
@@ -11,7 +11,7 @@
 		"testMatch": [
 			"<rootDir>/tests/*.js"
 		],
-		"runner": "groups",
+		"runner": "jest-runner-grouped-tests",
 		"verbose": true
 	}
 }

--- a/jest/25/package.json
+++ b/jest/25/package.json
@@ -11,7 +11,7 @@
 		"testMatch": [
 			"<rootDir>/tests/*.js"
 		],
-		"runner": "groups",
+		"runner": "jest-runner-grouped-tests",
 		"verbose": true
 	}
 }

--- a/jest/26/package.json
+++ b/jest/26/package.json
@@ -11,7 +11,7 @@
 		"testMatch": [
 			"<rootDir>/tests/*.js"
 		],
-		"runner": "groups",
+		"runner": "jest-runner-grouped-tests",
 		"verbose": true
 	}
 }

--- a/jest/27/package.json
+++ b/jest/27/package.json
@@ -11,7 +11,7 @@
 		"testMatch": [
 			"<rootDir>/tests/*.js"
 		],
-		"runner": "grouped-tests",
+		"runner": "jest-runner-grouped-tests",
 		"verbose": true
 	}
 }

--- a/jest/29/package.json
+++ b/jest/29/package.json
@@ -1,0 +1,17 @@
+{
+	"scripts": {
+		"test": "jest --group=valid"
+	},
+	"devDependencies": {
+		"jest": "^29.7.0",
+		"lodash": "^4.17.21"
+	},
+	"jest": {
+		"rootDir": "../..",
+		"testMatch": [
+			"<rootDir>/tests/*.js"
+		],
+		"runner": "jest-runner-grouped-tests",
+		"verbose": true
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jest-runner-grouped-tests",
-	"version": "2.2.2",
+	"version": "3.2.2",
 	"description": "Tag and run groups of tests with Jest",
 	"license": "MIT",
 	"author": "Eugene Manuilov <eugene.manuilov@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jest-runner-grouped-tests",
-	"version": "2.2.1",
+	"version": "2.2.2",
 	"description": "Tag and run groups of tests with Jest",
 	"license": "MIT",
 	"author": "Eugene Manuilov <eugene.manuilov@gmail.com>",


### PR DESCRIPTION
1. Remove tests for Nodejs 10, 12 as they are depreacted
2. Change the runner name
3. Add tests for jest 29 and node 20
4. Update Documentation 